### PR TITLE
Fix footer social icons align

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -76,7 +76,7 @@ export default class Footer extends Component {
             </div>
           </div>
           <div className={ gridStyle['col-4'] }>
-            <ul className={ style['p-inline-list--compact'] }>
+            <ul className={ `${style['p-inline-list--compact']} ${style['u-align--right']}` }>
               <li className={ style['p-inline-list__item'] }>
                 <a href="https://twitter.com/snapcraftio" className={ style['p-social-icon--twitter'] }>Share on Twitter</a>
               </li>

--- a/src/common/style/vanilla/css/footer.css
+++ b/src/common/style/vanilla/css/footer.css
@@ -48,6 +48,22 @@
     .p-footer__link:hover::after {
       color: #111; }
 
+.u-align--center {
+  justify-content: center !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  text-align: center !important; }
+
+.u-align--left {
+  justify-content: flex-start !important;
+  margin-right: auto !important;
+  text-align: left !important; }
+
+.u-align--right {
+  justify-content: flex-end !important;
+  margin-left: auto !important;
+  text-align: right !important; }
+
 .p-link--soft {
   color: #111; }
   .p-link--soft:visited {
@@ -641,6 +657,7 @@ body,
     background-image: url("https://assets.ubuntu.com/v1/6bfc3d6a-build.snapcraft.social.optimize.svg");
     background-repeat: no-repeat;
     background-size: 160px 80px;
+    color: transparent;
     display: inline-block;
     height: 40px;
     overflow: hidden;

--- a/src/common/style/vanilla/css/grid.css
+++ b/src/common/style/vanilla/css/grid.css
@@ -358,3 +358,9 @@ img {
 [grid-outline] [class*="col-"] {
   outline: 1px solid #fff;
   padding: 0.25rem; }
+
+.row {
+  box-sizing: border-box;
+  max-width: 64.875rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem; }

--- a/src/common/style/vanilla/footer.scss
+++ b/src/common/style/vanilla/footer.scss
@@ -1,6 +1,9 @@
 @import 'vanilla-framework/scss/patterns_footer.scss';
 @include vf-p-footer;
 
+@import 'vanilla-framework/scss/_utilities_content-align.scss';
+@include vf-u-align;
+
 // for external links
 @import 'vanilla-framework/scss/patterns_links.scss';
 @include vf-p-links;
@@ -68,6 +71,7 @@ body,
     background-image: url('#{$assets-path}6bfc3d6a-build.snapcraft.social.optimize.svg');
     background-repeat: no-repeat;
     background-size: 160px 80px; // 2x4 icons 40x40px each (in 2 rows for regular and hover state)
+    color: transparent;
     display: inline-block;
     height: 40px;
     overflow: hidden;

--- a/src/common/style/vanilla/grid.scss
+++ b/src/common/style/vanilla/grid.scss
@@ -1,3 +1,12 @@
 @import 'vanilla-framework/scss/patterns_grid.scss';
 @include vf-p-grid;
 @include vf-p-grid-modifications;
+
+// fix compatibility with newer version of Vanilla in snapcraft.io
+
+.row {
+  box-sizing: border-box;
+  max-width: 64.875rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}


### PR DESCRIPTION
Fixes #1218 

## Done

Updates alignment of footer social icons.
Fixes width of `.row` to make build.snapcraft.io styles consistent with Vanilla 1.7.

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Look at the footer. Width of the footer should be consistent with page width. Social icons should be right aligned.


<img width="1052" alt="Screenshot 2019-05-13 at 12 14 13" src="https://user-images.githubusercontent.com/83575/57614340-49bb1200-7579-11e9-9525-e737ceabd9bb.png">
