### PR TITLE
Update "Debug this build" instructions

### DIFF
--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -44,7 +44,7 @@ class BuildDetails extends Component {
             <br/>
             git clone {repository.url}<br/>
             cd {repository.name}<br/>
-            snapcraft cleanbuild --debug
+            snapcraft build --use-lxd --debug
           </HelpInstallSnap>
         </HelpBox>
       );


### PR DESCRIPTION
Since Snapcraft 3.4 you will need to use a different syntax to
test builds comparable with how the build.snapcraft.io build
system does builds.

Fixes #1194

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
