### PR TITLE
Add IoT to navigation

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -46,6 +46,9 @@ export default class Header extends Component {
               <li className={ style['p-navigation__link'] } role="menuitem">
                 <a href={ `${SNAPCRAFT_URL}/blog` }>Blog</a>
               </li>
+              <li className={ style['p-navigation__link'] } role="menuitem">
+                <a href={ `${SNAPCRAFT_URL}/iot` }>IoT</a>
+              </li>
               <li className={ `${style['p-navigation__link']} ${ authenticated ? style['is-selected'] : ''}` } role="menuitem">
                 <a href={ `${SNAPCRAFT_URL}/build` }>Build</a>
               </li>


### PR DESCRIPTION
## Done

Adds IoT page to navigation for snapcraft.io consistency

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Check if navigation contains IoT page, verify link works

