### PR TITLE
Add Extra Cache Headers To Build Badge Response

### DIFF
--- a/src/server/handlers/badge.js
+++ b/src/server/handlers/badge.js
@@ -30,7 +30,9 @@ export const badge = async (req, res) => {
       }
     }
 
-    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate, value');
+    res.setHeader('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT');
+    res.setHeader('Pragma', 'no-cache');
     return res.sendFile(path.join(BADGES_PATH, `${badgeName}.svg`));
   } catch (err) {
     logger.error(`Error generating badge for repo ${repoUrl}`, err);


### PR DESCRIPTION
Add extra cache prevention headers to the build badge response. This should help
reduce caching on GitHub README's.

I haven't tested it yet, but it is a very simple change.

## Done

- [x]  Add extra headers to build badge response
- [ ]  Test running site locally

## QA

- [ ]  Check out this feature branch
- [ ]  Run the site using the command ```npm start -- --env=environments/dev.env```
- [ ]  View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- [ ]  Try to test badge caching with a test GitHub README ( not sure if I will find a way to do this with a sandbox ).


## Issue / Card

Resolves #1248.