### PR TITLE
Use basic auth for GitHub

### DIFF
--- a/src/server/helpers/github.js
+++ b/src/server/helpers/github.js
@@ -38,8 +38,10 @@ export const requestGitHub = (options) => {
       // number of users.
       const parsedUri = url.parse(params.uri, true);
       delete parsedUri.search;
-      parsedUri.query.client_id = conf.get('GITHUB_AUTH_CLIENT_ID');
-      parsedUri.query.client_secret = conf.get('GITHUB_AUTH_CLIENT_SECRET');
+      const username = conf.get('GITHUB_AUTH_CLIENT_ID');
+      const password = conf.get('GITHUB_AUTH_CLIENT_SECRET');
+      const base64encodedAuth = new Buffer(`${username}:${password}`).toString('base64');
+      params.headers['Authorization'] = `Basic ${base64encodedAuth}`;
       params.uri = url.format(parsedUri);
     }
     params.headers['User-Agent'] = 'SnapcraftBuild';

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -223,24 +223,24 @@ describe('The WebHook API endpoint', () => {
 
           beforeEach(() => {
             const contentsPath = '/repos/anowner/aname/contents';
-            const query = {
-              client_id: conf.get('GITHUB_AUTH_CLIENT_ID'),
-              client_secret: conf.get('GITHUB_AUTH_CLIENT_SECRET')
+            const username = conf.get('GITHUB_AUTH_CLIENT_ID');
+            const password = conf.get('GITHUB_AUTH_CLIENT_SECRET');
+            const auth = new Buffer(`${username}:${password}`).toString('base64');
+            const headers = {
+              'Authorization': `Basic ${auth}`
             };
             const error = { message: 'Not Found' };
 
-            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'))
+            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'), {
+              reqheaders: headers
+            })
               .get(`${contentsPath}/snap/snapcraft.yaml`)
-              .query(query)
               .reply(404, error)
               .get(`${contentsPath}/build-aux/snap/snapcraft.yaml`)
-              .query(query)
               .reply(404, error)
               .get(`${contentsPath}/snapcraft.yaml`)
-              .query(query)
               .reply(404, error)
               .get(`${contentsPath}/.snapcraft.yaml`)
-              .query(query)
               .reply(404, error);
           });
 
@@ -283,12 +283,17 @@ describe('The WebHook API endpoint', () => {
           let buildRequest;
 
           beforeEach(() => {
-            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'))
+            const username = conf.get('GITHUB_AUTH_CLIENT_ID');
+            const password = conf.get('GITHUB_AUTH_CLIENT_SECRET');
+            const auth = new Buffer(`${username}:${password}`).toString('base64');
+            const headers = {
+              'Authorization': `Basic ${auth}`
+            };
+            
+            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'), {
+              reqheaders: headers
+            })
               .get('/repos/anowner/aname/contents/snap/snapcraft.yaml')
-              .query({
-                client_id: conf.get('GITHUB_AUTH_CLIENT_ID'),
-                client_secret: conf.get('GITHUB_AUTH_CLIENT_SECRET')
-              })
               .reply(200, 'name: dummy-test-snap\n');
             patchSnapAutoBuild = nock(lp_api_url)
               .post(`/devel${lp_snap_path}`, { auto_build: true })


### PR DESCRIPTION
## Done

- According to an email GitHub will [stop supporting query parameter auth](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters)
- Basic auth should be used instead
- [This page](https://developer.github.com/v3/apps/oauth_applications/#check-a-token) is a new endpoint that will check the validity of tokens - it says:
```
You must use Basic Authentication to use this endpoint, where the username is the OAuth application client_id and the password is its client_secret.
```
- I have implemented this and it seems to work locally

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Run the poller script and calls to GitHub should continue to succeed.


## Issue / Card

Fixes #1250 
