### PR TITLE
Add switch over info message

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -119,10 +119,19 @@ class RepositoriesHome extends Component {
       );
     }
 
+    // switch over to snapcraft.io/<snap_name>/builds notification
+    const infoNotification = (
+      <Notification appearance='information'>
+        We are updating the way you build from GitHub to integrate better within
+        Snapcraft. <a href="#">Learn more</a>
+      </Notification>
+    );
+
     return (
       <div>
         <FirstTimeHeading isOnMyRepos={true} />
         { errorNotification }
+        { infoNotification }
         <div className={ styles['button-container'] }>
           <HeadingThree>Repos to build</HeadingThree>
           <div>

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -123,7 +123,7 @@ class RepositoriesHome extends Component {
     const infoNotification = (
       <Notification appearance='information'>
         We are updating the way you build from GitHub to integrate better within
-        Snapcraft. <a href="#">Learn more</a>
+        Snapcraft. <a href="https://snapcraft.io/blog/we-are-changing-the-way-you-build-snaps-from-github-repos" target="_blank" rel="noopener noreferrer">Learn more</a>
       </Notification>
     );
 

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -81,7 +81,7 @@ describe('The RepositoriesHome component', () => {
     });
 
     it('should render error message', () => {
-      expect(wrapper.find('Notification').html()).toContain('Test error');
+      expect(wrapper.find('Notification').html().debug()).toContain('Test error');
     });
   });
 

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -81,7 +81,7 @@ describe('The RepositoriesHome component', () => {
     });
 
     it('should render error message', () => {
-      expect(wrapper.find('Notification').html().debug()).toContain('Test error');
+      expect(wrapper.find('Notification').first().html()).toContain('Test error');
     });
   });
 


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command ```npm start -- --env=environments/dev.env```
- View the site locally in your web browser at: [http://0.0.0.0:8000/](http://0.0.0.0:8000/)
- Good luck running it locally! If you manage to do it, see the notification and compare to [design](https://app.zeplin.io/project/5e283884b530e49813514f33/screen/5e427d8c527fe29a39d359b4)

**Once we have a blog post, the link in this  PR needs to be updated!**


## Issue / Card

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1289